### PR TITLE
Almost compliant macro processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .dub/
 __test__library__
+__test__lib__
 dub.selections.json
 libddoc.a
+./ddoc

--- a/dub.json
+++ b/dub.json
@@ -1,10 +1,21 @@
 {
 	"name": "libddoc",
-	"targetType": "library",
 	"targetName": "ddoc",
 	"description": "D implementation of the DDoc macro system",
 	"copyright": "Copyright © 2014-2015, Economic Modeling Specialists, Intl",
 	"authors": ["Brian Schott"],
 	"license": "BSL-1.0",
-	"homepage": "https://github.com/economicmodeling/libddoc"
+	"homepage": "https://github.com/economicmodeling/libddoc",
+	"configurations": [
+	{
+		"name": "lib",
+		"targetType": "library",
+		"versions": [ "LIBDDOC_CONFIG_LIB" ]
+	},
+	{
+		"name": "exe",
+		"targetType": "executable",
+		"versions": [ "LIBDDOC_CONFIG_EXE" ]
+	}
+	]
 }

--- a/dub.json
+++ b/dub.json
@@ -17,5 +17,8 @@
 		"targetType": "executable",
 		"versions": [ "LIBDDOC_CONFIG_EXE" ]
 	}
-	]
+	],
+	"dependencies": {
+		"libdparse": "~master"
+	}
 }

--- a/src/ddoc/comments.d
+++ b/src/ddoc/comments.d
@@ -10,31 +10,37 @@ import ddoc.lexer;
 
 Comment parseComment(string text, string[string] macros)
 {
-	Comment c;
-	bool hasSummary;
-	Lexer lexer = Lexer(text);
-	while (!lexer.empty) switch (lexer.front.type)
-	{
-	case Type.header:
-		string sectionName = lexer.front.text;
-		lexer.popFront();
-		c.sections ~= parseSection(sectionName, lexer, macros);
-		break;
-	case Type.whitespace:
-	case Type.newline:
-		lexer.popFront();
-		break;
-	default:
-		if (hasSummary)
-			c.sections ~= parseSection("Description", lexer, macros);
-		else
-		{
-			c.sections ~= parseSection("Summary", lexer, macros);
-			hasSummary = true;
-		}
-		break;
+	import std.algorithm : find;
+	import ddoc.macros : expand;
+	import ddoc.highlight;
+
+	auto sections = splitSections(text);
+	string[string] sMacros = macros;
+	auto m = sections.find!(p => p.name == "Macros");
+	auto e = sections.find!(p => p.name == "Escapes");
+	auto p = sections.find!(p => p.name == "Params");
+	if (m.length) {
+		if (!doMapping(m[0]))
+			throw new DdocParseException("Unable to parse Key/Value pairs", m[0].content);
+		foreach (kv; m[0].mapping)
+			sMacros[kv[0]] = kv[1];
 	}
-	return c;
+	if (e.length) {
+		assert(0, "Escapes not handled yet");
+	}
+	if (p.length) {
+		if (!doMapping(p[0]))
+			throw new DdocParseException("Unable to parse Key/Value pairs", m[0].content);
+		foreach (ref kv; p[0].mapping)
+			kv[1] = expand(Lexer(kv[1]), sMacros);
+	}
+
+	foreach (ref Section sec; sections) {
+		if (sec.name != "Macros" && sec.name != "Escapes"
+		    && sec.name != "Params")
+			sec.content = expand(Lexer(highlight(sec.content)), sMacros);
+	}
+	return Comment(sections);
 }
 
 struct Comment
@@ -74,13 +80,13 @@ Returns:
 	import std.string;
 //	writeln(c.sections);
 	assert(c.sections.length == 4, format("%d", c.sections.length));
-	assert(c.sections[0].name == "Summary");
+	assert(c.sections[0].name is null);
 	assert(c.sections[0].content == "Best-comment-ever © 2014", c.sections[0].content);
-	assert(c.sections[1].name == "Description");
+	assert(c.sections[1].name is null);
 	assert(c.sections[2].name == "Params");
 //	writeln(c.sections[2].mapping);
 	assert(c.sections[2].mapping[0][0] == "a");
-	assert(c.sections[2].mapping[0][1] == "$(A param)", c.sections[2].mapping[0][1]);
+	assert(c.sections[2].mapping[0][1] == `<a href="param">`, c.sections[2].mapping[0][1]);
 	assert(c.sections[3].name == "Returns");
 }
 
@@ -96,4 +102,82 @@ define a new root for specific dimensions.`c;
 	Comment c = parseComment(comment, macros);
 //	foreach (s; c.sections)
 //		writeln(s);
+}
+
+///
+unittest {
+	import std.format : text;
+	import ddoc.comments;
+
+	auto s1 = `Stop the world
+
+This function tells the Master to stop the world, taking effect immediately.
+
+Params:
+reason = Explanation to give to the $(B Master)
+duration = Time for which the world $(UNUSED)would be stopped (as time itself stop, this is always $(F double.infinity))
+
+---
+void main() {
+  import std.datetime : msecs;
+  import master.universe.control;
+  stopTheWorld("Too fast", 42.msecs);
+  assert(0); // Will never be reached.
+}
+---
+
+Returns:
+Nothing, because nobody can restart it.
+
+Macros:
+F= $0`;
+
+	auto expected = `<pre class="d_code"><font color=blue>void</font> main() {
+  <font color=blue>import</font> std.datetime : msecs;
+  <font color=blue>import</font> master.universe.control;
+  stopTheWorld(<font color=red>"Too fast"</font>, 42.msecs);
+  <font color=blue>assert</font>(0); <font color=green>// Will never be reached.</font>
+}</pre>`;
+
+	auto c = parseComment(s1, null);
+
+	assert(c.sections.length == 6, text(c.sections.length));
+	assert(c.sections[0].name is null, c.sections[0].name);
+	assert(c.sections[0].content == "Stop the world", c.sections[0].content);
+
+	assert(c.sections[1].name is null, c.sections[1].name);
+	assert(c.sections[1].content == `This function tells the Master to stop the world, taking effect immediately.`,
+	       c.sections[1].content);
+
+	assert(c.sections[2].name == "Params", c.sections[2].name);
+//	writeln(c.sections[2].mapping);
+	assert(c.sections[2].mapping[0][0] == "reason", c.sections[2].mapping[0][0]);
+	assert(c.sections[2].mapping[0][1] == "Explanation to give to the <b>Master</b>", c.sections[2].mapping[0][1]);
+	assert(c.sections[2].mapping[1][0] == "duration", c.sections[2].mapping[0][1]);
+	assert(c.sections[2].mapping[1][1] == "Time for which the world would be stopped (as time itself stop, this is always double.infinity)",
+	       c.sections[2].mapping[1][1]);
+
+	assert(c.sections[3].name == "Examples", c.sections[3].name);
+	assert(c.sections[3].content == expected, c.sections[3].content);
+
+	assert(c.sections[4].name == "Returns", c.sections[4].name);
+	assert(c.sections[4].content == `Nothing, because nobody can restart it.`, c.sections[4].content);
+
+	assert(c.sections[5].name == "Macros", c.sections[5].name);
+	assert(c.sections[5].mapping[0][0] == "F", c.sections[5].mapping[0][0]);
+	assert(c.sections[5].mapping[0][1] == "$0", c.sections[5].mapping[0][1]);
+}
+
+private:
+bool doMapping(ref Section s) {
+	import ddoc.macros : KeyValuePair, parseKeyValuePair;
+
+	auto lex = Lexer(s.content);
+	KeyValuePair[] pairs;
+	if (parseKeyValuePair(lex, pairs)) {
+		foreach (idx, kv; pairs)
+			s.mapping ~= kv;
+		return true;
+	}
+	return false;
 }

--- a/src/ddoc/comments.d
+++ b/src/ddoc/comments.d
@@ -80,7 +80,7 @@ Returns:
 	assert(c.sections[2].name == "Params");
 //	writeln(c.sections[2].mapping);
 	assert(c.sections[2].mapping[0][0] == "a");
-	assert(c.sections[2].mapping[0][1] == "<a href=\"param\">", c.sections[2].mapping[0][1]);
+	assert(c.sections[2].mapping[0][1] == "$(A param)", c.sections[2].mapping[0][1]);
 	assert(c.sections[3].name == "Returns");
 }
 

--- a/src/ddoc/highlight.d
+++ b/src/ddoc/highlight.d
@@ -1,0 +1,153 @@
+/**
+ * Perform highlighting on code section.
+ *
+ * DDOC string can contains embedded code. Those code can be highlighted by
+ * means of macros (keywork will be surrounded by $(DOLLAR)(D_KEYWORD),
+ * comments by $(DOLLAR)(D_COMMENT), etc...
+ * This module performs the highlighting.
+ *
+ * Copyright: © 2014 Economic Modeling Specialists, Intl.
+ * Authors: Brian Schott, Mathias 'Geod24' Lang
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ */
+module ddoc.highlight;
+
+/**
+ * Parses a string and replace embedded code (code between at least 3 '-') with
+ * the relevant macros.
+ *
+ * Params:
+ * str = A string that might contain embedded code. Only code will be modified.
+ *	 If the string doesn't contain any embedded code, it will be returned as is.
+ *
+ * Returns:
+ * A (possibly new) string containing the embedded code put in the proper macros.
+ */
+string highlight(string str) {
+	// Note: I don't think DMD is conformant w.r.t ddoc.
+	// The following file:
+	// Ddoc
+	// ----
+	// int main(string[] args) { return 0;}
+	// void test(int hello, string other);
+	// ----
+	//
+	// Produce the following document ($(DDOC) boilerplate excluded:
+	//
+	// <pre class="d_code"><font color=blue>int</font> main(string[] args) { <font color=blue>return</font> 0;}
+	// <font color=blue>void</font> test(<font color=blue>int</font> hello, string other);
+	// </pre>
+
+	import ddoc.lexer;
+	import ddoc.macros : tokOffset;
+	import std.array : appender;
+	import std.string : representation;
+	static import dlex = std.d.lexer;
+
+	enum fName = "<embedded-code-in-documentation>";
+	auto cache = dlex.StringCache(dlex.StringCache.defaultBucketCount);
+	auto lex = Lexer(str, true);
+	auto output = appender!string;
+	size_t start;
+	// We need this because there's no way to tell how many dashes precede
+	// an embedded.
+	size_t end;
+	while (!lex.empty) {
+		if (lex.front.type == Type.embedded) {
+			output.put(lex.text[start .. end]);
+			output.put("$(D_CODE ");
+			auto toks = dlex.byToken(lex.front.text.representation.dup,
+						 dlex.LexerConfig(fName, dlex.StringBehavior.source,
+								  dlex.WhitespaceBehavior.include), &cache);
+			while (!toks.empty) {
+				if (dlex.isStringLiteral(toks.front.type)) {
+					output.put("$(D_STRING ");
+					output.put(toks.front.text);
+					output.put(")");
+				} else if (toks.front == dlex.tok!"comment") {
+					output.put("$(D_COMMENT ");
+					output.put(toks.front.text);
+					output.put(")");
+				} else if (dlex.isKeyword(toks.front.type) || dlex.isBasicType(toks.front.type)) {
+					output.put("$(D_KEYWORD ");
+					output.put(dlex.str(toks.front.type));
+					output.put(")");
+				} else if (toks.front.text.length) {
+					output.put(toks.front.text);
+				} else {
+					output.put(dlex.str(toks.front.type));
+				}
+				toks.popFront();
+			}
+			output.put(")");
+			start = lex.offset;
+			lex.popFront();
+		}
+		end = lex.offset;
+		lex.popFront();
+	}
+	if (start)
+		output.put(lex.text[start .. end]);
+	return start ? output.data : str;
+}
+
+///
+unittest {
+	import ddoc.lexer;
+	
+	auto s1 = `Here is some embedded D code I'd like to show you:
+$(MY_D_CODE
+------
+// Entry point...
+void main() {
+  import std.stdio : writeln;
+  writeln("Hello,", " ", "world", "!");
+}
+------
+)
+Isn't it pretty ?`;
+	// Embedded code is surrounded by D_CODE macro, and tokens have their own
+	// macros (see: D_KEYWORD for example).
+	auto r1 = highlight(s1);
+	auto e1 = `Here is some embedded D code I'd like to show you:
+$(MY_D_CODE
+$(D_CODE $(D_COMMENT // Entry point...)
+$(D_KEYWORD void) main() {
+  $(D_KEYWORD import) std.stdio : writeln;
+  writeln($(D_STRING "Hello,"), $(D_STRING " "), $(D_STRING "world"), $(D_STRING "!"));
+})
+)
+Isn't it pretty ?`;
+	assert(r1 == e1, r1);
+
+	// No allocation is performed if the string doesn't contain inline code.
+	auto s2 = `This is some simple string
+--
+It doesn't do much
+--
+Hope you won't allocate`;
+	auto r2 = highlight(s2);
+	assert(r2 is s2, r2);
+}
+
+// Test multiple embedded code.
+unittest {
+	auto s1 = `----
+void main() {}
+----
+----
+int a = 42;
+----
+---
+unittest {
+    assert(42, "Life, universe, stuff");
+}
+---`;
+	auto e1 = `$(D_CODE $(D_KEYWORD void) main() {})
+$(D_CODE $(D_KEYWORD int) a = 42;)
+$(D_CODE $(D_KEYWORD unittest) {
+    $(D_KEYWORD assert)(42, $(D_STRING "Life, universe, stuff"));
+})`;
+	auto r1 = highlight(s1);
+	assert(r1 == e1, r1);
+}

--- a/src/ddoc/lexer.d
+++ b/src/ddoc/lexer.d
@@ -159,7 +159,7 @@ struct Lexer
 		}
 	}
 
-private:
+//private:
 
 	void lexWord()
 	{

--- a/src/ddoc/lexer.d
+++ b/src/ddoc/lexer.d
@@ -282,9 +282,25 @@ Returns:
  * (unmatching parenthesis, too much arguments to a macro...).
  */
 class DdocException : Exception {
+nothrow pure @safe:
 	this(string msg, string file = __FILE__,
-	     size_t line = __LINE__, Throwable next = null) pure nothrow @safe {
+	     size_t line = __LINE__, Throwable next = null) {
 		super(msg, file, line, next);
+	}
+
+	// Allow method chaining:
+	// throw new DdocException().snippet(lexer.text);
+	@property DdocException snippet(string s) { m_snippet = s; return this; }
+	@property string snippet() const { return m_snippet; }
+	private string m_snippet;
+}
+
+class DdocParseException : DdocException {
+nothrow pure @safe:
+	this(string msg, string code, string file = __FILE__,
+	     size_t line = __LINE__, Throwable next = null) {
+		super(msg, file, line, next);
+		this.snippet = code;
 	}
 }
 

--- a/src/ddoc/lexer.d
+++ b/src/ddoc/lexer.d
@@ -54,9 +54,10 @@ struct Lexer
 	 * Params:
 	 *     text = the _text to lex
 	 */
-	this(string text)
+	this(string text, bool skipHeader = false)
 	{
 		this.text = text;
+		this.parseHeader = !skipHeader;
 		popFront();
 	}
 
@@ -178,7 +179,7 @@ private:
 		}
 		current.type = Type.word;
 		current.text = text[oldOffset .. offset];
-		if (prevIsNewline(oldOffset, text) && offset < text.length && text[offset] == ':')
+		if (parseHeader && prevIsNewline(oldOffset, text) && offset < text.length && text[offset] == ':')
 		{
 			current.type = Type.header;
 			offset++;
@@ -210,6 +211,7 @@ private:
 	size_t offset;
 	string text;
 	bool _empty;
+	bool parseHeader;
 }
 
 unittest

--- a/src/ddoc/lexer.d
+++ b/src/ddoc/lexer.d
@@ -273,6 +273,18 @@ Returns:
 	assert (equal(l.map!(a => a.type), expected));
 }
 
+/**
+ * Class for library exception.
+ *
+ * Most often, this is thrown when a Ddoc document is misformatted
+ * (unmatching parenthesis, too much arguments to a macro...).
+ */
+class DdocException : Exception {
+	this(string msg, string file = __FILE__,
+	     size_t line = __LINE__, Throwable next = null) pure nothrow @safe {
+		super(msg, file, line, next);
+	}
+}
 
 bool prevIsNewline(size_t offset, immutable string text) pure nothrow
 {

--- a/src/ddoc/macros.d
+++ b/src/ddoc/macros.d
@@ -189,10 +189,9 @@ void collectMacroArguments(ref Lexer input, string[string] macros,
 	auto plusApp = appender!string();
 	auto currentApp = appender!string();
 	int depth = 1;
-	while (!input.empty)
-	{
-		if (input.front.type == Type.dollar)
-		{
+loop:	while (!input.empty) {
+		switch (input.front.type) {
+		case Type.dollar:
 			input.popFront();
 			if (input.front.type == Type.lParen)
 			{
@@ -219,9 +218,8 @@ void collectMacroArguments(ref Lexer input, string[string] macros,
 				if (i > 1)
 					plusApp.put("$");
 			}
-		}
-		else if (input.front.type == Type.comma)
-		{
+			break;
+		case Type.comma:
 			if (i < 9)
 			{
 				arguments[i] = currentApp.data;
@@ -235,9 +233,8 @@ void collectMacroArguments(ref Lexer input, string[string] macros,
 				zeroApp.put(input.front.text);
 				input.popFront();
 			}
-		}
-		else if (input.front.type == Type.lParen)
-		{
+			break;
+		case Type.lParen:
 			depth++;
 			if (i < 10)
 				currentApp.put(input.front.text);
@@ -245,14 +242,13 @@ void collectMacroArguments(ref Lexer input, string[string] macros,
 			if (i > 1)
 				plusApp.put(input.front.text);
 			input.popFront();
-		}
-		else if (input.front.type == Type.rParen)
-		{
+			break;
+		case Type.rParen:
 			if (--depth == 0)
 			{
 				arguments[i] = currentApp.data;
 				input.popFront();
-				break;
+				break loop;
 			}
 			else
 			{
@@ -263,9 +259,8 @@ void collectMacroArguments(ref Lexer input, string[string] macros,
 					plusApp.put(input.front.text);
 				input.popFront();
 			}
-		}
-		else
-		{
+			break;
+		default:
 			if (i < 10)
 				putInApp(currentApp, input.front);
 			putInApp(zeroApp, input.front);

--- a/src/ddoc/macros.d
+++ b/src/ddoc/macros.d
@@ -12,6 +12,8 @@ import std.range;
 import std.algorithm;
 import std.stdio;
 
+alias KeyValuePair = Tuple!(string, string);
+
 immutable string[string] DEFAULT_MACROS;
 
 shared static this()
@@ -358,4 +360,91 @@ unittest
 	expandMacros(l, macros, result);
 	assert (result.data == expected, result.data);
 //	writeln(result.data);
+}
+
+/**
+ * Parses macros declaration, in the forms of 'NAME=VALUE'
+ *
+ * Returns: true if the parsing succeeded
+ */
+bool parseKeyValuePair(ref Lexer lexer, ref KeyValuePair[] pairs, string[string] macros)
+{
+	import std.array;
+	string key;
+	while (!lexer.empty && (lexer.front.type == Type.whitespace
+		|| lexer.front.type == Type.newline))
+	{
+		lexer.popFront();
+	}
+	if (!lexer.empty && lexer.front.type == Type.word)
+	{
+		key = lexer.front.text;
+		lexer.popFront();
+	}
+	else
+		return false;
+	while (!lexer.empty && lexer.front.type == Type.whitespace)
+		lexer.popFront();
+	if (!lexer.empty && lexer.front.type == Type.equals)
+		lexer.popFront();
+	else
+		return false;
+	if (lexer.front.type == Type.whitespace)
+		lexer.popFront();
+	auto app = appender!string();
+	loop: while (!lexer.empty) switch (lexer.front.type)
+	{
+	case Type.newline:
+		Lexer savePoint = lexer;
+		while (!lexer.empty && (lexer.front.type == Type.newline || lexer.front.type == Type.whitespace))
+			lexer.popFront();
+		if (lexer.front.type == Type.word)
+		{
+			string w = lexer.front.text;
+			lexer.popFront();
+			bool ws;
+			while (!lexer.empty && lexer.front.type == Type.whitespace)
+			{
+				ws = true;
+				lexer.popFront();
+			}
+			if (lexer.front.type == Type.equals)
+			{
+				lexer = savePoint;
+				break loop;
+			}
+			else
+			{
+				app.put(" ");
+				app.put(w);
+				if (ws)
+					app.put(" ");
+			}
+		}
+		else if (lexer.front.type == Type.header)
+			break loop;
+		else
+		{
+			if (!lexer.empty)
+				app.put(" ");
+			app.put(lexer.front.text);
+			lexer.popFront();
+		}
+		break;
+	case Type.whitespace:
+		app.put(" ");
+		lexer.popFront();
+		break;
+	case Type.header:
+		break loop;
+	default:
+		app.put(lexer.front.text);
+		lexer.popFront();
+//		break;
+	}
+	Lexer l = Lexer(app.data);
+	auto val = appender!string();
+	expandMacros(l, macros, val);
+	pairs ~= KeyValuePair(key, val.data);
+	return true;
 }

--- a/src/ddoc/macros.d
+++ b/src/ddoc/macros.d
@@ -805,9 +805,14 @@ string lookup(in string name, in string[string] macros, string defVal = null) {
 	return *p;
 }
 
-void stripWhitespace(ref Lexer lexer) {
-	while (!lexer.empty && (lexer.front.type == Type.whitespace || lexer.front.type == Type.newline))
+/// Returns: The number of offset skipped.
+package size_t stripWhitespace(ref Lexer lexer) {
+	size_t start = lexer.offset;
+	while (!lexer.empty && (lexer.front.type == Type.whitespace || lexer.front.type == Type.newline)) {
+		start = lexer.offset;
 		lexer.popFront();
+	}
+	return start;
 }
 
 enum callHighlightMsg = "You should call ddoc.hightlight.hightlight(string) first.";

--- a/src/ddoc/macros.d
+++ b/src/ddoc/macros.d
@@ -1,10 +1,99 @@
 /**
+ * Functions to work with DDOC macros.
+ *
+ * Provide functionalities to perform various macro-related operations, including:
+ * - Expand a text, with $(D expand).
+ * - Expand a macro, with $(D expandMacro);
+ * - Parse macro files (.ddoc), with $(D parseMacrosFile);
+ * - Parse a "Macros:" section, with $(D parseKeyValuePair);
+ * To work with embedded documentation ('.dd' files), see $(D ddoc.standalone).
+ *
+ * Most functions provide two interfaces. One takes an $(D OutputRange) to write to,
+ * and the other one is a convenience wrapper around it, which returns a string.
+ * It uses an $(D std.array.Appender) as the output range.
+ *
+ * Most functions take a 'macros' parameter. The user is not required to pass
+ * the standard D macros in it if he wants HTML output, the same macros that
+ * are hardwired into DDOC are hardwired into libddoc (B, I, D_CODE, etc...).
+ *
  * Copyright: © 2014 Economic Modeling Specialists, Intl.
- * Authors: Brian Schott
- * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt Boost License 1.0)
+ * Authors: Brian Schott, Mathias 'Geod24' Lang
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  */
-
 module ddoc.macros;
+
+///
+unittest {
+	import std.format : text;
+	import ddoc.lexer;
+
+	// Ddoc has some hardwired macros, which will be automatically searched.
+	// List here: dlang.org/ddoc.html
+	auto l1 = Lexer(`A simple $(B Hello $(I world))`);
+	auto r1 = expand(l1, null);
+	assert(r1 == `A simple <b>Hello <i>world</i></b>`, r1);
+
+	// Example on how to parse ddoc file / macros sections.
+	KeyValuePair[] pairs;
+	auto lm2 = Lexer(`GREETINGS  =  Hello $(B $0)
+			  IDENTITY = $0`);
+	// Acts as we are parsing a ddoc file.
+	assert(parseKeyValuePair(lm2, pairs));
+	// parseKeyValuePair parses up to the first invalid token, or until
+	// a section is reached. It returns false on parsing failure.
+	assert(lm2.empty, lm2.front.text);
+	assert(pairs.length == 2, text("Expected length 2, got: ", pairs.length));
+	string[string] m2;
+	foreach (kv; pairs)
+		m2[kv[0]] = kv[1];
+	// Macros are not expanded until the final call site.
+	// This allow for forward reference of macro and recursive macros.
+	assert(m2.get(`GREETINGS`, null) == `Hello $(B $0)`, m2.get(`GREETINGS`, null));
+	assert(m2.get(`IDENTITY`, null) == `$0`, m2.get(`IDENTITY`, null));
+
+	// There are some more specialized functions in this module, such as
+	// expandMacro which expects the lexer to be placed on a macro, and
+	// will consume the input (unlike expand, which exhaust a copy).
+	auto l2 = Lexer(`$(GREETINGS $(IDENTITY John Doe))`);
+	auto r2 = expand(l2, m2);
+	assert(r2 == `Hello <b>John Doe</b>`, r2);
+
+	// Note that the expansions are not processed recursively.
+	// Hence, it's possible to have DDOC-formatted code inside DDOC.
+	auto l3 = Lexer(`This $(DOLLAR)(MACRO) do not expand recursively.`);
+	auto r3 = expand(l3, null);
+	auto e3 = `This $(MACRO) do not expand recursively.`;
+	assert(e3 == r3, r3);
+
+	// The code can contains embedded code, which will be highlighted by
+	// macros substitution (see corresponding DDOC macros).
+	// The substitution is *NOT* performed by DDOC, and must be done by
+	// calling $(D parseEmbedded) first.
+	// If you forget to do so, libddoc will consider this as a developper
+	// mistake, and will kindly inform you with an assertion error.
+	auto s4 = `Here is some embedded D code I'd like to show you:
+$(MY_D_CODE
+------
+void main() {
+  import std.stdio : writeln;
+  writeln("Hello,", " ", "world", "!");
+}
+------
+)
+Isn't it pretty ?`;
+	auto l4 = Lexer(parseEmbedded(s4));
+	// Embedded code is surrounded by D_CODE macro, and tokens have their own
+	// macros (see: TODO).
+	auto r4 = expand(l4, [ "MY_D_CODE": "<code>$1</code>", "D_CODE": "$0" ]);
+	auto e4 = `Here is some embedded D code I'd like to show you:
+<code>void main() {
+  import std.stdio : writeln;
+  writeln("Hello,", " ", "world", "!");
+}
+</code>
+Isn't it pretty ?`;
+	assert(r4 == e4, r4);
+}
 
 import ddoc.lexer;
 import std.exception;
@@ -14,6 +103,7 @@ import std.stdio;
 
 alias KeyValuePair = Tuple!(string, string);
 
+/// The set of ddoc's predefined macros.
 immutable string[string] DEFAULT_MACROS;
 
 shared static this()
@@ -39,7 +129,7 @@ shared static this()
 		 `LPAREN` : `(`,
 		 `RPAREN` : `)`,
 		 `DOLLAR` : `$`,
-		 `BACKTIP` : "`",
+		 `BACKTICK` : "`",
 		 `DEPRECATED` : `$0`,
 
 		 `RED` :   `<font color=red>$0</font>`,
@@ -118,9 +208,9 @@ shared static this()
 }
 
 /**
- * Expand  the macros present in the given lexer and write them to an $(D OutputRange).
+ * Write the text from the lexer to the $(D OutputRange), and expand any macro in it..
  *
- * expandMacros takes a $(D ddoc.Lexer), and will, until it's empty, write it's expanded version to $(D output).
+ * expand takes a $(D ddoc.Lexer), and will, until it's empty, write it's expanded version to $(D output).
  *
  * Params:
  * input = A reference to the lexer to use. When expandMacros successfully returns, it will be empty.
@@ -130,25 +220,82 @@ shared static this()
  *		To undefine hardwired macros, just set them to an empty string: $(D macros["B"] = "";).
  * output = An object satisfying $(D std.range.isOutputRange), usually a $(D std.array.Appender).
  */
-void expandMacros(O)(ref Lexer input, string[string] macros, O output)
-	if (isOutputRange!(O, string))
-{
-	while (!input.empty)
-	{
-		if (input.front.type == Type.dollar)
-		{
+void expand(O)(Lexer input, in string[string] macros, O output) if (isOutputRange!(O, string)) {
+	// First, we need to turn every embedded code into a $(D_CODE)
+	while (!input.empty) {
+		assert(input.front.type != Type.embedded,
+		       "You should call parseEmbedded first");
+		if (input.front.type == Type.dollar) {
 			input.popFront();
-			if (input.front.type == Type.lParen)
-				output.put(expandMacro(input, macros));
-			else
+			if (input.front.type == Type.lParen) {
+				auto mac = Lexer(matchParenthesis(input), true);
+				if (!mac.empty)
+					expandMacroImpl(mac, macros, output);
+			} else
 				output.put("$");
-		}
-		else
-		{
+		} else {
 			output.put(input.front.text);
 			input.popFront();
 		}
 	}
+ }
+
+/// Ditto
+string expand(Lexer input, string[string] macros) {
+	import std.array : appender;
+	auto app = appender!string();
+	expand(input, macros, app);
+	return app.data;
+}
+
+unittest {
+	auto lex = Lexer(`Dat logo: $(LOGO dlang, Beautiful dlang logo)`);
+	auto r = expand(lex, [ `LOGO` : `<img src="images/$1_logo.png" alt="$2">`]);
+	auto exp = `Dat logo: <img src="images/dlang_logo.png" alt="Beautiful dlang logo">`;
+	assert(r == exp, r);
+}
+
+/**
+ * Expand a macro, and write the result to an $(D OutputRange).
+ *
+ * It's the responsability of the caller to ensure that the lexer contains the
+ * beginning of a macro. The front of the input should be either a dollar
+ * followed an opening parenthesis, or an opening parenthesis.
+ *
+ * If the macro does not have a closing parenthesis, input will be exhausted
+ * and a $(D DdocException) will be thrown.
+ *
+ * Params:
+ * input = A reference to a lexer with front pointing to the macro.
+ * macros = Additional macros to use, in addition of DDOC's ones.
+ * output = An $(D OutputRange) to write to.
+ */
+void expandMacro(O)(ref Lexer input, in string[string] macros, O output) if (isOutputRange!(O, string)) in {
+		import std.format : text;
+		assert(input.front.type == Type.dollar
+		       || input.front.type == Type.lParen,
+		       text("$ or ( expected, not ", input.front.type));
+} body {
+	import std.format : text;
+
+	if (input.front.type == Type.dollar)
+		input.popFront();
+	assert(input.front.type == Type.lParen, text(input.front.type));
+	auto l = Lexer(matchParenthesis(input), true);
+	expandMacroImpl(l, macros, output);
+ }
+
+/// Ditto
+string expandMacro(ref Lexer input, in string[string] macros) in {
+	import std.format : text;
+	assert(input.front.type == Type.dollar
+	       || input.front.type == Type.lParen,
+	       text("$ or ( expected, not ", input.front.type));
+} body {
+	import std.array : appender;
+	auto app = appender!string();
+	expandMacro(input, macros, app);
+	return app.data;
 }
 
 ///
@@ -158,217 +305,143 @@ unittest {
 
 	auto macros =
 		[
-		 // Note: You should NOT try to expand any recursive macro.
 		 "IDENTITY": "$0",
 		 "HWORLD": "$(IDENTITY Hello world!)",
 		 "ARGS": "$(IDENTITY $1 $+)",
-		 "GREETINGS": "$(IDENTITY $(ARGS Hello, $0))",
+		 "GREETINGS": "$(IDENTITY $(ARGS Hello,$0))",
 		 ];
-	foreach (k, ref v; macros) {
-		auto lex = Lexer(v);
-		auto app = appender!string();
-		expandMacros(lex, macros, app);
-		v = app.data;
-	}
 
-	assert(macros["IDENTITY"] == "$0", macros["IDENTITY"]);
-	assert(macros["HWORLD"] == "Hello world!", macros["HWORLD"]);
-	assert(macros["ARGS"] == "$1 $+", macros["ARGS"]);
-	assert(macros["GREETINGS"] == "Hello $0", macros["GREETINGS"]);
+	auto l1 = Lexer(`$(HWORLD)`);
+	auto r1 = expandMacro(l1, macros);
+	assert(r1 == "Hello world!", r1);
 
-	auto lex = Lexer(`$(B $(IDENTITY $(GREETINGS John Malkovich)))`);
-	auto app = appender!string();
-	expandMacros(lex, macros, app);
-	auto result = app.data;
-	assert(result == "<b>Hello John Malkovich</b>", result);
+	auto l2 = Lexer(`$(B $(IDENTITY $(GREETINGS John Malkovich)))`);
+	auto r2 = expandMacro(l2, macros);
+	assert(r2 == "<b>Hello John Malkovich</b>", r2);
+
+	// Macros that have should take args but don't get them expand to empty string.
+	auto l3 = Lexer(`$(GREETINGS)`);
+	auto r3 = expandMacro(l3, macros);
+	//assert(r3 == "", r3);
 }
 
-void collectMacroArguments(ref Lexer input, string[string] macros,
-	ref string[11] arguments)
-{
-	size_t i = 1;
-	auto zeroApp = appender!string();
-	auto plusApp = appender!string();
-	auto currentApp = appender!string();
-	int depth = 1;
-loop:	while (!input.empty) {
-		switch (input.front.type) {
-		case Type.dollar:
-			input.popFront();
-			if (input.front.type == Type.lParen)
-			{
-				string s = expandMacro(input, macros);
-				while (s.canFind("$("))
-				{
-					auto a = appender!string();
-					Lexer l = Lexer(s);
-					expandMacros(l, macros, a);
-					s = a.data;
-				}
-				zeroApp.put(s);
-				if (i < 10)
-					currentApp.put(s);
-				if (i > 1)
-					plusApp.put(s);
-				continue;
-			}
-			else
-			{
-				zeroApp.put("$");
-				if (i < 10)
-					currentApp.put("$");
-				if (i > 1)
-					plusApp.put("$");
-			}
-			break;
-		case Type.comma:
-			if (i < 9)
-			{
-				arguments[i] = currentApp.data;
-				currentApp = appender!string();
-				i++;
-			}
-			zeroApp.put(input.front.text);
-			input.popFront();
-			while (!input.empty && (input.front.type == Type.whitespace || input.front.type == Type.newline))
-			{
-				zeroApp.put(input.front.text);
-				input.popFront();
-			}
-			break;
-		case Type.lParen:
-			depth++;
-			if (i < 10)
-				currentApp.put(input.front.text);
-			zeroApp.put(input.front.text);
-			if (i > 1)
-				plusApp.put(input.front.text);
-			input.popFront();
-			break;
-		case Type.rParen:
-			if (--depth == 0)
-			{
-				arguments[i] = currentApp.data;
-				input.popFront();
-				break loop;
-			}
-			else
-			{
-				if (i < 10)
-					currentApp.put(input.front.text);
-				zeroApp.put(input.front.text);
-				if (i > 1)
-					plusApp.put(input.front.text);
-				input.popFront();
-			}
-			break;
-		default:
-			if (i < 10)
-				putInApp(currentApp, input.front);
-			putInApp(zeroApp, input.front);
-			if (i > 1)
-				putInApp(plusApp, input.front);
-			input.popFront();
-		}
-	}
-	arguments[0] = zeroApp.data;
-	arguments[$ - 1] = plusApp.data;
+/// A simple example, with recursive macros:
+unittest {
+	import ddoc.lexer;
+
+	auto lex = Lexer(`$(MYTEST Un,jour,mon,prince,viendra)`);
+	auto macros = [ `MYTEST`: `$1 $(MYTEST $+)` ];
+	// Note: There's also a version of expand that takes an OutputRange.
+	auto result = expand(lex, macros);
+	assert(result == `Un jour mon prince viendra `, result);
 }
 
-void putInApp(App)(ref App app, Token token)
-{
-	if (token.type == Type.embedded)
-	{
-		app.put("<pre><code>");
-		app.put(token.text);
-		app.put("</code></pre>");
-	}
-	else
-		app.put(token.text);
+unittest {
+	import std.array;
+	auto macros =
+		[
+		 "D" : "<b>$0</b>",
+		 "P" : "<p>$(D $0)</p>",
+		 "KP" : "<b>$1</b><i>$+</i>",
+		 "LREF" : `<a href="#$1">$(D $1)</a>`
+		 ];
+	auto l = Lexer(`$(D something $(KP a, b) $(P else), abcd) $(LREF byLineAsync)`c);
+	auto expected = `<b>something <b>a</b><i>b</i> <p><b>else</b></p>, abcd</b> <a href="#byLineAsync"><b>byLineAsync</b></a>`;
+	auto result = appender!string();
+	expand(l, macros, result);
+	assert (result.data == expected, result.data);
+	// writeln(result.data);
 }
 
-string expandMacro(ref Lexer input, string[string] macros)
-{
-	auto output = appender!string();
-	if (input.front.type == Type.dollar)
-		input.popFront();
-	if (input.front.type != Type.lParen)
-	{
-		writeln("lparen expected");
-		return "";
-	}
-	input.popFront();
-	if (input.front.type != Type.word)
-		return "";
-	string macroName = input.front.text;
-	input.popFront();
-	while (!input.empty && (input.front.type == Type.whitespace || input.front.type == Type.newline))
-		input.popFront();
-	string[11] arguments;
-	collectMacroArguments(input, macros, arguments);
-	string macroValue;
-	{
-		const(string)* p = macroName in macros;
-		if (p is null)
-			if ((p = macroName in DEFAULT_MACROS) is null)
-				return "";
-		macroValue = *p;
-	}
-	if (macroValue.canFind("$("))
-	{
-		auto mv = appender!string();
-		Lexer l = Lexer(macroValue);
-		expandMacros(l, macros, mv);
-		macroValue = mv.data;
-	}
-	for (size_t i = 0; i < macroValue.length; i++)
-	{
-		if (macroValue[i] == '$' && i + 1 < macroValue.length)
-		{
-			int c = macroValue[i + 1] - '0';
-			if (c >= 0 && c < 10)
-			{
-				output.put(arguments[c]);
-				i++;
-			}
-			else if (macroValue[i + 1] == '+')
-			{
-				output.put(arguments[$ - 1]);
-				i++;
-			}
-			else
-				output.put("$");
+unittest {
+	auto l1 = Lexer("Do you have a $(RPAREN) problem with $(LPAREN) me?");
+	auto r1 = expand(l1, null);
+	assert(r1 == "Do you have a ) problem with ( me?", r1);
+
+	auto l2 = Lexer("And (with $(LPAREN) me) ?");
+	auto r2 = expand(l2, null);
+	assert(r2 == "And (with ( me) ?", r2);
+
+	auto l3 = Lexer("What about $(TEST me) ?");
+	auto r3 = expand(l3, [ "TEST": "($0" ]);
+	assert(r3 == "What about (me ?", r3);
+}
+
+/**
+ * Parse a string and replace embedded code (code between at least 3 '-') with
+ * the relevant macros.
+ *
+ * Params:
+ * str = A string that might contain embedded code. Only code will be modified.
+ *
+ * Returns:
+ * A (possibly new) string containing the embedded code put in the proper macros.
+ */
+string parseEmbedded(string str) {
+	auto lex = Lexer(str, true);
+	auto output = appender!string;
+	while (!lex.empty) {
+		if (lex.front.type == Type.embedded) {
+			output.put("$(D_CODE ");
+			output.put(lex.front.text);
+			output.put(")");
 		}
 		else
-			output.put(macroValue[i]);
+			output.put(lex.front.text);
+		lex.popFront();
 	}
 	return output.data;
 }
 
+/**
+ * Parses macros files, usually with extension .ddoc.
+ *
+ * Macros files are files that only contains macros definitions.
+ * Newline after a macro is part of this macro, so a blank line between
+ * macro A and macro B will lead to macro A having a trailing newline.
+ * If you wish to split your file in blocks, terminate each block with
+ * a dummy macro, e.g: '_' (underscore).
+ *
+ * Params:
+ * paths = A variadic array with paths to ddoc files.
+ *
+ * Returns:
+ * An associative array containing all the macros parsed from the files.
+ * In case of multiple definitions, macros are overriden.
+ */
+string[string] parseMacrosFile(R)(R paths) if (isInputRange!(R)) {
+	import std.exception : enforceEx;
+	import std.file : readText;
+	import std.format : text;
 
-unittest
-{
-	import std.array;
-	auto macros = [
-		"D" : "<b>$0</b>",
-		"P" : "<p>$(D $0)</p>",
-		"KP" : "<b>$1</b><i>$+</i>",
-		"LREF" : `<a href="#$1">$(D $1)</a>`];
-	auto l = Lexer(`$(D something $(KP a, b) $(P else), abcd) $(LREF byLineAsync)`c);
-	auto expected = `<b>something <b>a</b><i>b</i> <p><b>else</b></p>, abcd</b> <a href="#byLineAsync"><b>byLineAsync</b></a>`;
-	auto result = appender!string();
-	expandMacros(l, macros, result);
-	assert (result.data == expected, result.data);
-//	writeln(result.data);
+	string[string] ret;
+	foreach (file; paths) {
+		KeyValuePair[] pairs;
+		auto txt = readText(file);
+		auto lexer = Lexer(txt, true);
+		parseKeyValuePair(lexer, pairs);
+		enforceEx!DdocException(lexer.empty, text("Unparsed data (", lexer.offset, "): ", lexer.text[lexer.offset..$]));
+		foreach (kv; pairs)
+			ret[kv[0]] = kv[1];
+	}
+	return ret;
 }
 
 /**
- * Parses macros declaration list, in the forms of 'NAME=VALUE'
+ * Parses macros (or params) declaration list until the lexer is empty.
  *
- * Returns: true if the parsing succeeded
+ * Macros are simple Key/Value pair. So, a macro is declared as: NAME=VALUE.
+ * Any number of whitespace (space / tab) can precede and follow the equal sign.
+ *
+ * Params:
+ * lexer = A reference to lexer consisting solely of macros definition (if $(D stopAtSection) is false),
+ *	   or consisting of a macro followed by other sections.
+ *	   Consequently, at the end of the parsing, the lexer will be empty or may point to a section.
+ * pairs = A reference to an array of $(D KeyValuePair), where the macros will be stored.
+ *
+ * Returns: true if the parsing succeeded.
  */
-bool parseKeyValuePair(ref Lexer lexer, ref KeyValuePair[] pairs, string[string] macros, bool stopAtSection = true)
-{
+bool parseKeyValuePair(ref Lexer lexer, ref KeyValuePair[] pairs) {
 	import std.array : appender;
 	import std.format : text;
 	string prevKey, key;
@@ -380,18 +453,17 @@ bool parseKeyValuePair(ref Lexer lexer, ref KeyValuePair[] pairs, string[string]
 		if (!parseAsKeyValuePair(lexer, key, value)) {
 			if (prevKey == null) // First pass and invalid data
 				return false;
-			if (stopAtSection && lexer.front.type == Type.header)
+			if (lexer.front.type == Type.header)
 				break;
 			assert(lexer.offset >= prevValue.length);
-			size_t start = lexer.offset - lexer.front.text.length
-				- prevValue.length;
+			size_t start = tokOffset(lexer)	- prevValue.length;
 			while (!lexer.empty && lexer.front.type != Type.newline) {
 				lexer.popFront();
 			}
 			prevValue = lexer.text[start..lexer.offset];
 		} else {
 			// New macro, we can save the previous one.
-			// The only case when key would not be defined is
+			// The only case when key would not be defined is on first pass.
 			if (prevKey)
 				pairs ~= KeyValuePair(prevKey, prevValue);
 			prevKey = key;
@@ -408,16 +480,57 @@ bool parseKeyValuePair(ref Lexer lexer, ref KeyValuePair[] pairs, string[string]
 	if (prevKey)
 		pairs ~= KeyValuePair(prevKey, prevValue);
 
-	// Expand macros
-	if (macros !is null) {
-		foreach (ref kv; pairs) {
-			auto l = Lexer(kv[1]);
-			auto val = appender!string();
-			expandMacros(l, macros, val);
-			kv[1] = val.data;
-		}
-	}
 	return true;
+}
+
+private:
+// upperArgs is a string[11] actually, or null.
+void expandMacroImpl(O)(Lexer input, in string[string] macros, O output) {
+	import std.format : text;
+
+	//debug writeln("Expanding: ", input.text);
+	// Check if the macro exist and get it's value.
+	if (input.front.type != Type.word)
+		return;
+	string macroName = input.front.text;
+	//debug writeln("[EXPAND] Macro name: ", input.front.text);
+	string macroValue = lookup(macroName, macros);
+	// No point loosing time if the macro is undefined.
+	if (macroValue is null) return;
+	//debug writeln("[EXPAND] Macro value: ", macroValue);
+	input.popFront();
+
+	// Special case for $(DDOC). It's ugly, but it gets the job done.
+	if (input.empty && macroName == "BODY") {
+		output.put(lookup("BODY", macros));
+		return;
+	}
+	input.popFront();
+
+	// Collect the arguments
+	if (!input.empty && (input.front.type == Type.whitespace || input.front.type == Type.newline))
+		input.popFront();
+	string[11] arguments;
+	auto c = collectMacroArguments(input, arguments);
+	//debug writeln("[EXPAND] There are ", c, " arguments");
+
+	// First pass
+	auto argOutput = appender!string();
+	if (!replaceArgs(macroValue, arguments, argOutput))
+		return;
+
+	// Second pass
+	replaceMacs(argOutput.data, macros, output);
+}
+
+unittest {
+	auto a1 = appender!string();
+	expandMacroImpl(Lexer(`B value`), null, a1);
+	assert(a1.data == `<b>value</b>`, a1.data);
+
+	auto a2 = appender!string();
+	expandMacroImpl(Lexer(`IDENTITY $(B value)`), [ "IDENTITY": "$0" ], a2);
+	assert(a2.data == `<b>value</b>`, a2.data);
 }
 
 // Try to parse a line as a KeyValuePair, returns false if it fails
@@ -427,12 +540,10 @@ private bool parseAsKeyValuePair(ref Lexer olexer, ref string key, ref string va
 	while (!lexer.empty && (lexer.front.type == Type.whitespace
 				|| lexer.front.type == Type.newline))
 		lexer.popFront();
-	if (!lexer.empty && lexer.front.type == Type.word)
-	{
+	if (!lexer.empty && lexer.front.type == Type.word) {
 		_key = lexer.front.text;
 		lexer.popFront();
-	}
-	else
+	} else
 		return false;
 	while (!lexer.empty && lexer.front.type == Type.whitespace)
 		lexer.popFront();
@@ -444,38 +555,304 @@ private bool parseAsKeyValuePair(ref Lexer olexer, ref string key, ref string va
 		lexer.popFront();
 	assert(lexer.offset > 0, "Something is wrong with the lexer");
 	// Offset points to the END of the token, not the beginning.
-	size_t start = lexer.offset - lexer.front.text.length;
+	size_t start = tokOffset(lexer);
 	while (!lexer.empty && lexer.front.type != Type.newline) {
 		assert(lexer.front.type != Type.header);
 		lexer.popFront();
 	}
 	olexer = lexer;
 	key = _key;
-	size_t end = lexer.offset - ((start != lexer.offset) ? (1) : (0));
+	size_t end = lexer.offset - ((start != lexer.offset && lexer.offset != lexer.text.length) ? (1) : (0));
 	value = lexer.text[start..end];
 	return true;
 }
 
-/**
- * Parses macros files, usually with extension .ddoc.
- *
- * Macros files are files that only contains macros definitions.
- */
-string[string] parseMacrosFile(string[] paths...) {
-	import std.exception : enforce;
-	import std.file : readText;
+// Note: For macro $(NAME arg1,arg2), collectMacroArguments receive "arg1,arg2".
+size_t collectMacroArguments(Lexer input, ref string[11] args) {
 	import std.format : text;
 
-	string[string] ret;
-	foreach (file; paths) {
-		KeyValuePair[] pairs;
-		auto txt = readText(file);
-		auto lexer = Lexer(txt);
-		parseKeyValuePair(lexer, pairs, null, false);
-		enforce(lexer.empty, text("Unparsed data (", lexer.offset, "): ",
-					  lexer.text[lexer.offset..$]));
-		foreach (kv; pairs)
-			ret[kv[0]] = kv[1];
+	size_t argPos = 1;
+	size_t argStart = tokOffset(input);
+	args[] = null;
+	if (input.empty) return 0;
+	args[0] = input.text[tokOffset(input) .. $];
+	while (!input.empty) {
+		assert(input.front.type != Type.embedded, "You should call parseEmbedded first");
+		switch (input.front.type) {
+		case Type.comma:
+			if (argPos <= 9)
+				args[argPos++] = input.text[argStart .. (input.offset - 1)];
+			input.popFront();
+			stripWhitespace(input);
+			argStart = tokOffset(input);
+			// Set the $+ parameter.
+			if (argPos == 2)
+				args[10] = input.text[tokOffset(input) .. $];
+			break;
+		case Type.lParen:
+			// Advance the lexer to the matching parenthesis.
+			auto err = input.text[input.offset..$];
+			auto substr = matchParenthesis(input);
+			break;
+			// TODO: Implement ", ' and <-- pairing.
+		default:
+			input.popFront();
+		}
 	}
-	return ret;
+	assert(argPos >= 1 && argPos <= 10, text(argPos));
+	if (argPos <= 9)
+		args[argPos] = input.text[argStart .. input.offset];
+	return argPos;
+}
+
+unittest {
+	import std.format : text;
+	string[11] args;
+
+	auto l1 = Lexer(`Hello, world`);
+	auto c1 = collectMacroArguments(l1, args);
+	assert(c1 == 2, text(c1));
+	assert(args[0] == `Hello, world`, args[0]);
+	assert(args[1] == `Hello`, args[1]);
+	assert(args[2] == `world`, args[2]);
+	for (size_t i = 3; i < 10; ++i)
+		assert(args[i] is null, args[i]);
+	assert(args[10] == `world`, args[10]);
+
+	auto l2 = Lexer(`goodbye,cruel,world,I,will,happily,return,home`);
+	auto c2 = collectMacroArguments(l2, args);
+	assert(c2 == 8, text(c2));
+	assert(args[0] == `goodbye,cruel,world,I,will,happily,return,home`, args[0]);
+	assert(args[1] == `goodbye`, args[1]);
+	assert(args[2] == `cruel`, args[2]);
+	assert(args[3] == `world`, args[3]);
+	assert(args[4] == `I`, args[4]);
+	assert(args[5] == `will`, args[5]);
+	assert(args[6] == `happily`, args[6]);
+	assert(args[7] == `return`, args[7]);
+	assert(args[8] == `home`, args[8]);
+	assert(args[9] is null, args[9]);
+	assert(args[10] == `cruel,world,I,will,happily,return,home`, args[10]);
+
+	// It's not as easy as a split !
+	auto l3 = Lexer(`this,(is,(just,two),args)`);
+	auto c3 = collectMacroArguments(l3, args);
+	assert(c3 == 2, text(c3));
+	assert(args[0] == `this,(is,(just,two),args)`, args[0]);
+	assert(args[1] == `this`, args[1]);
+	assert(args[2] == `(is,(just,two),args)`, args[2]);
+	for (size_t i = 3; i < 10; ++i)
+		assert(args[i] is null, args[i]);
+	assert(args[10] == `(is,(just,two),args)`, args[10]);
+
+	auto l4 = Lexer(``);
+	auto c4 = collectMacroArguments(l4, args);
+	assert(c4 == 0, text(c4));
+	for (size_t i = 0; i < 11; ++i)
+		assert(args[i] is null, args[i]);
+
+	import std.string : split;
+	enum first = `I,am,happy,to,join,with,you,today,in,what,will,go,down,in,history,as,the,greatest,demonstration,for,freedom,in,the,history,of,our,nation.`;
+	auto l5 = Lexer(first);
+	auto c5 = collectMacroArguments(l5, args);
+	assert(c5 == 10, text(c5));
+	assert(args[0] == first, args[0]);
+	foreach (idx, word; first.split(",")[0..9])
+		assert(args[idx+1] == word, text(word , " != ", args[idx+1]));
+	assert(args[10] == first[2..$], args[10]);
+
+	// TODO: ", ', {, <--, matched and unmatched.
+}
+
+// Where the grunt work is done...
+
+bool replaceArgs(O)(string val, in string[11] args, O output) {
+	import std.format : text;
+	import std.ascii : isDigit;
+
+	bool hasEnd;
+	auto lex = Lexer(val, true);
+	while (!lex.empty) {
+		assert(lex.front.type != Type.embedded, "You should call parseEmbedded first");
+		switch (lex.front.type) {
+		case Type.dollar:
+			lex.popFront();
+			// It could be $1_test
+			if (isDigit(lex.front.text[0])) {
+				auto idx = lex.front.text[0] - '0';
+				assert(idx >= 0 && idx <= 9, text(idx));
+				// Missing argument
+				if (args[idx] is null)
+					return false;
+				output.put(args[idx]);
+				output.put(lex.front.text[1..$]);
+				lex.popFront();
+			} else if (lex.front.text == "+") {
+				lex.popFront();
+				output.put(args[10]);
+			} else {
+				output.put("$");
+			}
+			break;
+		case Type.lParen:
+			output.put("(");
+			if (!replaceArgs(matchParenthesis(lex, &hasEnd), args, output))
+				return false;
+			if (hasEnd)
+				output.put(")");
+			break;
+		default:
+			output.put(lex.front.text);
+			lex.popFront();
+		}
+	}
+	return true;
+}
+
+unittest {
+	string[11] args;
+
+	auto a1 = appender!string;
+	args[0] = "Some kind of test, I guess";
+	args[1] = "Some kind of test";
+	args[2] = " I guess";
+	assert(replaceArgs("$(MY $(SUPER $(MACRO $0)))", args, a1));
+	assert(a1.data == "$(MY $(SUPER $(MACRO Some kind of test, I guess)))",
+	       a1.data);
+
+	auto a2 = appender!string;
+	args[] = null;
+	args[0] = "Some,kind,of,test";
+	args[1] = "Some";
+	args[2] = "kind";
+	args[3] = "of";
+	args[4] = "test";
+	args[10] = "kind,of,test";
+	assert(replaceArgs("$(SOME $(MACRO $1 $+))", args, a2));
+	assert(a2.data == "$(SOME $(MACRO Some kind,of,test))", a2.data);
+
+	auto a3 = appender!string;
+	args[] = null;
+	args[0] = "Some,kind";
+	args[1] = "Some";
+	args[2] = "kind";
+	args[10] = "kind";
+	assert(!replaceArgs("$(SOME $(MACRO $1 $2 $3))", args, a3));
+}
+
+void replaceMacs(O)(string val, in string[string] macros, O output) {
+	//debug writeln("[REPLACE] Arguments replaced: ", val);
+	bool hasEnd;
+	auto lex = Lexer(val, true);
+	while (!lex.empty) {
+		assert(lex.front.type != Type.embedded, "You should call parseEmbedded first");
+		switch (lex.front.type) {
+		case Type.dollar:
+			lex.popFront();
+			if (lex.front.type == Type.lParen)
+				expandMacro(lex, macros, output);
+			else
+				output.put("$");
+			break;
+		case Type.lParen:
+			output.put("(");
+			auto par = matchParenthesis(lex, &hasEnd);
+			expand(Lexer(par), macros, output);
+			if (hasEnd)
+				output.put(")");
+			break;
+		default:
+			output.put(lex.front.text);
+			lex.popFront();
+		}
+	}
+}
+
+// Some utilities functions
+
+/**
+ * Must be called with a parenthesis as the front item of $(D lexer).
+ * Will move the lexer forward until a matching parenthesis is met,
+ * taking nesting into account.
+ * If no matching parenthesis is met, returns null (and $(D lexer) will be empty).
+ */
+string matchParenthesis(ref Lexer lexer, bool* hasEnd = null) in {
+	import std.format : text;
+	assert(lexer.front.type == Type.lParen, text(lexer.front));
+	assert(lexer.offset);
+} body {
+	size_t count;
+	size_t start = lexer.offset;
+	do {
+		if (lexer.front.type == Type.rParen)
+			--count;
+		else if (lexer.front.type == Type.lParen)
+			++count;
+		lexer.popFront();
+	} while (count > 0 && !lexer.empty);
+	size_t end = (lexer.empty) ? lexer.text.length : tokOffset(lexer);
+	if (hasEnd !is null) *hasEnd = (count == 0);
+	if (count == 0) end -= 1;
+	return lexer.text[start .. end];
+}
+
+unittest {
+	auto l1 = Lexer(`(Hello) World`);
+	auto r1 = matchParenthesis(l1);
+	assert(r1 == "Hello", r1);
+	assert(!l1.empty);
+
+	auto l2 = Lexer(`()`);
+	auto r2 = matchParenthesis(l2);
+	assert(r2 == "", r2);
+	assert(l2.empty);
+
+	auto l3 = Lexer(`(())`);
+	auto r3 = matchParenthesis(l3);
+	assert(r3 == "()", r3);
+	assert(l3.empty);
+
+	auto l4 = Lexer(`W (He(l)lo)`);
+	l4.popFront(); l4.popFront();
+	auto r4 = matchParenthesis(l4);
+	assert(r4 == "He(l)lo", r4);
+	assert(l4.empty);
+
+	auto l5 = Lexer(` @(Hello())   ()`);
+	l5.popFront(); l5.popFront();
+	auto r5 = matchParenthesis(l5);
+	assert(r5 == "Hello()", r5);
+	assert(!l5.empty);
+
+	auto l6 = Lexer(`(Hello()   (`);
+	auto r6 = matchParenthesis(l6);
+	assert(r6 == "Hello()   (", r6);
+	assert(l6.empty);
+}
+
+size_t tokOffset(in Lexer lex) { return lex.offset - lex.front.text.length; }
+
+unittest {
+	import std.format : text;
+
+	auto lex = Lexer(`My  (friend) $ lives abroad`);
+	auto expected = [0, 2, 4, 5, 11, 12, 13, 14, 15, 20, 21];
+	while (!lex.empty) {
+		assert(expected.length > 0, "Test and results are not in sync");
+		assert(tokOffset(lex) == expected[0], text(lex.front, " : ", tokOffset(lex), " -- ", expected[0]));
+		lex.popFront();
+		expected = expected[1..$];
+	}
+}
+
+string lookup(in string name, in string[string] macros, string defVal = null) {
+	auto p = name in macros;
+	if (p is null)
+		return DEFAULT_MACROS.get(name, defVal);
+	return *p;
+}
+
+void stripWhitespace(ref Lexer lexer) {
+	while (!lexer.empty && (lexer.front.type == Type.whitespace || lexer.front.type == Type.newline))
+		lexer.popFront();
 }

--- a/src/ddoc/sections.d
+++ b/src/ddoc/sections.d
@@ -15,7 +15,7 @@ import std.typecons;
 immutable string[] STANDARD_SECTIONS = [
 	"Authors", "Bugs", "Copyright", "Date",
 	"Deprecated", "Examples", "History", "License",
-	"Returns", "See_also", "Standards", "Throws",
+	"Returns", "See_Also", "Standards", "Throws",
 	"Version"
 ];
 
@@ -86,41 +86,168 @@ Section parseMacrosOrParams(string name, ref Lexer lexer, ref string[string] mac
 }
 
 /**
- * Parses a section.
+ * Split a text into sections.
+ *
+ * Takes a text, which is generally a full comment (usually you'll also call
+ * $(D unDecorateComment) before). It splits it in an array of $(D Section)
+ * and returns it.
+ * Whatever the content of $(D text) is, this function will always return an
+ * array of at least 2 items. Those 2 sections are the "Summary" and "Description"
+ * sections (which may be empty).
+ *
  * Params:
- *     name = the section name
- *     lexer = the lexer
- *     macros = the macros used for substitution
- * Returns: the parsed section
+ * text = A DDOC-formatted comment.
+ *
+ * Returns:
+ * An array of $(D Section) with at least 2 elements.
  */
-Section parseSection(string name, ref Lexer lexer, ref string[string] macros)
-{
-	import ddoc.macros : tokOffset;
-	if (name == "Macros" || name == "Params" || name == "Escapes")
-		return parseMacrosOrParams(name, lexer, macros);
+Section[] splitSections(string text) {
+	import std.array : appender;
 
-	Section s;
-	s.name = name;
-	size_t start = tokOffset(lexer);
-	size_t end = start;
-	loop: while (!lexer.empty) switch (lexer.front.type)
-	{
+	/*
+	 * Note: The specs says those sections are unnamed. So some people could
+	 * name one of it's section 'Summary' or 'Description', and it would be
+	 * legal (but arguably wrong).
+	 */
+	auto lex = Lexer(text);
+	auto app = appender!(Section[]);
+	bool hasSum, hasDesc;
+	// Used to strip trailing newlines / whitespaces.
+	size_t offset, end;
+	string name;
+	app ~= [ Section(), Section() ];
+	// Strip leading whitespace
+	//end = offset = lex.stripWhitespace();
+	while (!lex.empty) switch (lex.front.type) {
 	case Type.header:
-		break loop;
-	case Type.newline:
-		lexer.popFront();
-		if (lexer.empty || (name == "Summary" && lexer.front.type == Type.newline))
-		{
-			lexer.popFront();
-			break loop;
+		if (hasSum && hasDesc) {
+			assert(name !is null);
+			appendSection(name, lex.text[offset..end], app);
 		}
-		end = lexer.offset;
+		if (!hasSum) {
+			hasSum = true;
+			app.data[0].content = lex.text[offset..end];
+			end = offset = lex.offset;
+		}
+		if (!hasDesc) {
+			hasDesc = true;
+			app.data[1].content = lex.text[offset..end];
+			end = offset = lex.offset;
+		}
+		name = lex.front.text;
+		lex.popFront();
+		end = offset = lex.stripWhitespace();
+		break;
+	case Type.newline:
+		lex.popFront();
+		if (!hasSum && lex.front.type == Type.newline) {
+			hasSum = true;
+			app.data[0].content = lex.text[offset..end];
+			end = offset = lex.offset;
+			lex.popFront();
+		}
+		break;
+	case Type.embedded:
+		// If examples are contiguous to each others
+		if (name != "Examples") {
+			string prev = lex.text[offset..end];
+			if (!hasSum) {
+				app.data[0].content = prev;
+				hasSum = hasDesc = true;
+			} else if (!hasDesc) {
+				hasDesc = true;
+				app.data[0].content = prev;
+			} else
+				appendSection(name, prev, app);
+			name = "Examples";
+			auto tmp = Lexer(lex.text[end .. $]);
+			offset = end + tmp.stripWhitespace();
+			end = lex.offset;
+			lex.popFront();
+		} else
+			end = lex.offset;
 		break;
 	default:
-		end = lexer.offset;
-		lexer.popFront();
+		end = lex.offset;
+		lex.popFront();
 		break;
 	}
-	s.content = lexer.text[start .. end];
-	return s;
+
+	if (name !is null)
+		appendSection(name, lex.text[offset..end], app);
+
+	return app.data;
+}
+
+unittest {
+	import std.format : text;
+
+	auto s1 = `Short comment.
+Still comment.
+
+Description.
+Still desc...
+
+Still
+
+Authors:
+Me & he
+Bugs:
+None
+Copyright:
+Date:
+
+Deprecated:
+Nope,
+
+------
+void foo() {}
+----
+
+History:
+License:
+Returns:
+See_Also
+See_Also:
+Standards:
+
+Throws:
+Version:
+
+
+`;
+	auto cnt =
+		[ "Short comment.\nStill comment.",
+		  "Description.\nStill desc...\n\nStill",
+		  "Me & he", "None", "", "", "Nope,",
+		  "------\nvoid foo() {}\n----", "", "",
+		  "See_Also", "", "", "", "" ];
+	foreach (idx, sec; splitSections(s1)) {
+		if (idx < 2) // Summary & description
+			assert(sec.name is null, sec.name);
+		else
+			assert(sec.name == STANDARD_SECTIONS[idx-2], sec.name);
+		assert(sec.content == cnt[idx],
+		       text(sec.name, " (", idx, "): ", sec.content));
+	}
+}
+
+private:
+/// Append a section to the given output or merge it if a section with
+/// the same name already exists.
+///
+/// Returns:
+/// $(D true) if the section did not already exists,
+/// $(D false) if the content was merged with an existing section.
+bool appendSection(O)(string name, string content, ref O output) in {
+	assert(name !is null, "You should not call appendSection with a null name");
+} body {
+	for (size_t i = 2; i < output.data.length; ++i) {
+		if (output.data[i].name == name) {
+			output.data[i].content ~= content;
+			return false;
+		}
+	}
+	output ~= Section(name, content);
+	return true;
 }

--- a/src/ddoc/sections.d
+++ b/src/ddoc/sections.d
@@ -74,7 +74,7 @@ Section parseMacrosOrParams(string name, ref Lexer lexer, ref string[string] mac
 		string[string] m;
 		if (name != "Macros")
 			m = macros;
-		if (!parseKeyValuePair(lexer, s.mapping, m))
+		if (!parseKeyValuePair(lexer, s.mapping))
 			break;
 		if (name == "Macros")
 		{

--- a/src/ddoc/sections.d
+++ b/src/ddoc/sections.d
@@ -9,8 +9,6 @@ import ddoc.lexer;
 import ddoc.macros;
 import std.typecons;
 
-alias KeyValuePair = Tuple!(string, string);
-
 /**
  * Standard section names
  */
@@ -85,91 +83,6 @@ Section parseMacrosOrParams(string name, ref Lexer lexer, ref string[string] mac
 		}
 	}
 	return s;
-}
-
-/**
- * Returns: true if the parsing succeeded
- */
-bool parseKeyValuePair(ref Lexer lexer, ref KeyValuePair[] pairs, string[string] macros)
-{
-	import std.array;
-	string key;
-	while (!lexer.empty && (lexer.front.type == Type.whitespace
-		|| lexer.front.type == Type.newline))
-	{
-		lexer.popFront();
-	}
-	if (!lexer.empty && lexer.front.type == Type.word)
-	{
-		key = lexer.front.text;
-		lexer.popFront();
-	}
-	else
-		return false;
-	while (!lexer.empty && lexer.front.type == Type.whitespace)
-		lexer.popFront();
-	if (!lexer.empty && lexer.front.type == Type.equals)
-		lexer.popFront();
-	else
-		return false;
-	if (lexer.front.type == Type.whitespace)
-		lexer.popFront();
-	auto app = appender!string();
-	loop: while (!lexer.empty) switch (lexer.front.type)
-	{
-	case Type.newline:
-		Lexer savePoint = lexer;
-		while (!lexer.empty && (lexer.front.type == Type.newline || lexer.front.type == Type.whitespace))
-			lexer.popFront();
-		if (lexer.front.type == Type.word)
-		{
-			string w = lexer.front.text;
-			lexer.popFront();
-			bool ws;
-			while (!lexer.empty && lexer.front.type == Type.whitespace)
-			{
-				ws = true;
-				lexer.popFront();
-			}
-			if (lexer.front.type == Type.equals)
-			{
-				lexer = savePoint;
-				break loop;
-			}
-			else
-			{
-				app.put(" ");
-				app.put(w);
-				if (ws)
-					app.put(" ");
-			}
-		}
-		else if (lexer.front.type == Type.header)
-			break loop;
-		else
-		{
-			if (!lexer.empty)
-				app.put(" ");
-			app.put(lexer.front.text);
-			lexer.popFront();
-		}
-		break;
-	case Type.whitespace:
-		app.put(" ");
-		lexer.popFront();
-		break;
-	case Type.header:
-		break loop;
-	default:
-		app.put(lexer.front.text);
-		lexer.popFront();
-//		break;
-	}
-	Lexer l = Lexer(app.data);
-	auto val = appender!string();
-	expandMacros(l, macros, val);
-	pairs ~= KeyValuePair(key, val.data);
-	return true;
 }
 
 /**

--- a/src/ddoc/standalone.d
+++ b/src/ddoc/standalone.d
@@ -1,0 +1,194 @@
+/**
+ * Parser for standalone ".dd" files.
+ *
+ * See_Also: dlang.org/ddoc.html ("Using Ddoc for other Documentation" section).
+ * Copyright: © 2014 Economic Modeling Specialists, Intl.
+ * Authors: Mathias Lang
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt Boost License 1.0)
+ */
+module ddoc.standalone;
+
+import std.stdio;
+
+import ddoc.lexer;
+import ddoc.sections;
+import ddoc.macros;
+
+string parseFile(string path, in string[string] context) {
+	import std.conv : to;
+	import std.datetime : Clock;
+	import std.file : readText;
+	import std.path : baseName, stripExtension;
+
+	auto text = readText(path);
+	// Predefined DDOC macros.
+	// The user might want to provide his macros.
+	// It makes sense for some (e.g. TITLE), not really for
+	// DATETIME / YEAR, but the macros file are supposed to
+	// override the predefinition, not the other way around.
+	string[string] macros = context.aaDup;
+	if (("TITLE" in macros) is null)
+		macros["TITLE"] = baseName(path).stripExtension;
+	if (("DATETIME" in macros) is null)
+		macros["DATETIME"] = Clock.currTime.toSimpleString;
+	if (("YEAR" in macros) is null)
+		macros["YEAR"] = to!string(Clock.currTime.year);
+	// parseDDString has to fill up COPYRIGHT
+	if (("DOCFILENAME" in macros) is null) // FIXME ??
+		macros["DOCFILENAME"] = path.stripExtension~".html";
+	if (("SRCFILENAME" in macros) is null)
+		macros["SRCFILENAME"] = baseName(path);
+
+	macros["BODY"] = parseDDString(text, macros);
+	return parseDdocBody(macros);
+}
+
+string parseDDString(string text, string[string] macros)
+{
+	import std.string : strip;
+	import std.algorithm : startsWith;
+	import std.array : appender;
+
+	assert(text.startsWith("Ddoc"), "the string should start with 'Ddoc'");
+
+	// First thing, we turn embedded doc into macros
+	text = parseEmbedded(text[4..$]);
+	
+	// The doc is between "Ddoc" (which must be at the beginning of the file)
+	// and the "Macros" sections. So first we need to find the later.
+	// Get macros and expand them.
+	parseMacrosSection(text, macros);
+
+	// Get the copyright section
+	auto copyright = getSection("Copyright", Lexer(text), macros).content;
+	if (copyright !is null)
+		macros["COPYRIGHT"] = copyright;
+	auto lexer = Lexer(text, true);
+	return expand(lexer, macros);
+}
+
+///
+unittest {
+	import std.stdio, std.string;
+
+	auto text = `Ddoc
+	This file is a standalone Ddoc file. It can contain any kind of
+	$(MAC macros), defined in the $(MAC 'Macros:' section).
+
+Macros:
+	MAC=$0
+	_=
+`;
+
+	auto expected = `This file is a standalone Ddoc file. It can contain any kind of
+	macros, defined in the 'Macros:' section.`;
+
+	auto lex = Lexer(text, true);
+	// Whitespace and newline before / after not taken into account.
+	auto res = parseDDString(text, null).strip;
+	assert(res == expected, res);
+}
+
+private Section getSection(string name, Lexer lexer, ref string[string] macros) {
+	while (!lexer.empty)
+		switch (lexer.front.type) {
+		case Type.header:
+			string sectionName = lexer.front.text;
+			if (sectionName == name) {
+				return parseSection(name, lexer, macros);
+			}
+			goto default;
+		default:
+			lexer.popFront();
+			break;
+		}
+	return typeof(return).init;
+}
+
+private string parseDdocBody(string[string] macros) {
+	auto lexer = Lexer("$(DDOC)", true);
+	return expandMacro(lexer, macros);
+}
+
+
+private void parseMacrosSection(ref string text, ref string[string] macros) {
+	import std.string : indexOf;
+	enum macSection = "\nMacros:\n";
+	auto idx = text.indexOf(macSection);
+	if (idx >= 0) {
+		auto macroSection = text[idx + macSection.length .. $];
+		KeyValuePair[] kvp;
+		auto lex = Lexer(macroSection, true);
+		assert(parseKeyValuePair(lex, kvp));
+		foreach (kv; kvp) macros[kv[0]] = kv[1];
+		text = text[0..idx];
+	}
+}
+
+// BUG #14148
+private auto aaDup(in string[string] aa) {
+	string[string] ret;
+	foreach (k, v; aa)
+		ret[k] = v;
+	return ret;
+}
+
+version (LIBDDOC_CONFIG_EXE):
+int main(string[] args) {
+	import std.algorithm;
+	import std.getopt;
+	import std.path;
+	static import file = std.file;
+
+	if (args.length == 1) {
+		stderr.writeln(`Usage: `, args[0], ` [options] [macros.ddoc]* file.dd`);
+		stderr.writeln();
+		stderr.writeln(`Process standalone documentation files and write them to a file.`);
+		stderr.writeln(`'.ddoc' files are macros definition file. Order matters.`);
+		stderr.writeln();
+		stderr.writeln(`Options:`);
+		stderr.writeln(`-o|--output-file=path\tOutput a (single) parsed file to 'path';`);
+		stderr.writeln(`-D|--output-dir=dir\tOutput all parsed file(s) to directory 'dir';`);
+	}
+
+	args = args[1..$];
+	string outDir, outFile;
+	getopt(args,
+	       "output-dir|D", &outDir,
+	       "output-file|o", &outFile
+	       );
+	auto ddocFiles = args.filter!((f) => f.extension == ".ddoc");
+
+	if (!args.any!((f) => f.extension == ".dd")) {
+		stderr.writeln("No .dd file provided");
+		return 1;
+	}
+
+	bool oneFile;
+	auto ctx = parseMacrosFile(ddocFiles);
+	foreach (f; args) {
+		if (f.extension == ".ddoc")
+			continue;
+		assert(f.extension == ".dd", "Don't know what to do with "~f);
+		if (oneFile) {
+			stderr.writeln("Only one .dd file allowed with o|output-file.");
+			return 1;
+		}
+		oneFile = (outFile !is null);
+		writeln("Processing file : ", f);
+		auto data = parseFile(f, ctx);
+		if (outFile !is null) {
+			writeln("Writing ", data.length, " bytes to ", outFile);
+			file.write(outFile, data);
+		} else if (outDir !is null) {
+			auto of = buildPath(outDir, baseName(f.setExtension(".html")));
+			writeln("Writing ", data.length, " bytes to ", of);
+			file.write(of, data);
+		} else {
+			auto of = baseName(f.setExtension(".html"));
+			writeln("Writing ", data.length, " bytes to ", of);
+			file.write(of, data);
+		}
+	}
+	return 0;
+}

--- a/src/ddoc/standalone.d
+++ b/src/ddoc/standalone.d
@@ -45,6 +45,7 @@ string parseFile(string path, in string[string] context) {
 
 string parseDDString(string text, string[string] macros)
 {
+	import ddoc.highlight;
 	import std.string : strip;
 	import std.algorithm : startsWith;
 	import std.array : appender;
@@ -52,7 +53,7 @@ string parseDDString(string text, string[string] macros)
 	assert(text.startsWith("Ddoc"), "the string should start with 'Ddoc'");
 
 	// First thing, we turn embedded doc into macros
-	text = parseEmbedded(text[4..$]);
+	text = highlight(text[4..$]);
 	
 	// The doc is between "Ddoc" (which must be at the beginning of the file)
 	// and the "Macros" sections. So first we need to find the later.

--- a/src/ddoc/standalone.d
+++ b/src/ddoc/standalone.d
@@ -51,10 +51,8 @@ string parseDDString(string text, string[string] macros)
 	import std.array : appender;
 
 	assert(text.startsWith("Ddoc"), "the string should start with 'Ddoc'");
+	text = text[4 .. $];
 
-	// First thing, we turn embedded doc into macros
-	text = highlight(text[4..$]);
-	
 	// The doc is between "Ddoc" (which must be at the beginning of the file)
 	// and the "Macros" sections. So first we need to find the later.
 	// Get macros and expand them.
@@ -64,6 +62,7 @@ string parseDDString(string text, string[string] macros)
 	auto copyright = getSection("Copyright", Lexer(text), macros).content;
 	if (copyright !is null)
 		macros["COPYRIGHT"] = copyright;
+	text = highlight(text);
 	auto lexer = Lexer(text, true);
 	return expand(lexer, macros);
 }
@@ -106,11 +105,11 @@ private Section getSection(string name, Lexer lexer, ref string[string] macros) 
 	return typeof(return).init;
 }
 
+// Warning: Does not support embedded code / inlining.
 private string parseDdocBody(string[string] macros) {
 	auto lexer = Lexer("$(DDOC)", true);
 	return expandMacro(lexer, macros);
 }
-
 
 private void parseMacrosSection(ref string text, ref string[string] macros) {
 	import std.string : indexOf;

--- a/src/ddoc/standalone.d
+++ b/src/ddoc/standalone.d
@@ -59,9 +59,9 @@ string parseDDString(string text, string[string] macros)
 	parseMacrosSection(text, macros);
 
 	// Get the copyright section
-	auto copyright = getSection("Copyright", Lexer(text), macros).content;
-	if (copyright !is null)
-		macros["COPYRIGHT"] = copyright;
+	//auto copyright = getSection("Copyright", text, macros).content;
+	//if (copyright !is null)
+	//	macros["COPYRIGHT"] = copyright;
 	text = highlight(text);
 	auto lexer = Lexer(text, true);
 	return expand(lexer, macros);
@@ -87,22 +87,6 @@ Macros:
 	// Whitespace and newline before / after not taken into account.
 	auto res = parseDDString(text, null).strip;
 	assert(res == expected, res);
-}
-
-private Section getSection(string name, Lexer lexer, ref string[string] macros) {
-	while (!lexer.empty)
-		switch (lexer.front.type) {
-		case Type.header:
-			string sectionName = lexer.front.text;
-			if (sectionName == name) {
-				return parseSection(name, lexer, macros);
-			}
-			goto default;
-		default:
-			lexer.popFront();
-			break;
-		}
-	return typeof(return).init;
 }
 
 // Warning: Does not support embedded code / inlining.


### PR DESCRIPTION
Sorry for the big diff.

This is an almost compliant library implementation of the standalone part of DDOC.
It parses all of dlang.org and can store it in memory (I'm trying to move dlang.org to Vibe.d, example [here](http://doc.mimiks.net:8000/), demo code [here](https://github.com/Geod24/dlang.org/blob/63b2e0bb45caa50ada0db3acabafdc0b8a8089c4/source/dlang/web/pages.d)).

I end up with a refactor because the previous version did not take into account recursives macros, a la `RECUR = $1 $(RECUR $+)`.
What's left to do:
- handle ESCAPE
- syntactic coloration: complete parseEmbedded
- matching of ', " and <!-- is not taken into account.