### PR TITLE
Handle indentation in code blocks

### DIFF
--- a/src/ddoc/highlight.d
+++ b/src/ddoc/highlight.d
@@ -133,6 +133,28 @@ $(D_CODE $(D_KEYWORD unittest) {
 	assert(r1 == e1, r1);
 }
 
+unittest {
+	auto s = `
+        ---------
+        asm pure nothrow @nogc @trusted
+        {
+            // the compiler does not check the attributes
+            ret;
+        }
+        ---------
+`;
+	auto e = `
+        $(D_CODE $(D_KEYWORD asm) $(D_KEYWORD pure) $(D_KEYWORD nothrow) @nogc @trusted
+{
+    $(D_COMMENT // the compiler does not check the attributes)
+    ret;
+}
+)
+`;
+	auto r = highlight(s);
+	assert (r == e, r);
+}
+
 private:
 void highlightCode(O)(string code, ref O output) {
 	import std.d.lexer;


### PR DESCRIPTION
One of the last thing that was bugging me (and the ability to render dlang.org properly) was the extra indentation in code blocks. I tried to handle it in the highlighter, but it wasn't really a solution (involved a lot of corner case / dirty code). I believe the proper fix is in the lexer.