### PR TITLE
Fix importing of a symbol in the wrong module

### DIFF
--- a/src/ddoc/macros.d
+++ b/src/ddoc/macros.d
@@ -373,7 +373,7 @@ unittest {
 string[string] parseMacrosFile(R)(R paths) if (isInputRange!(R)) {
 	import std.exception : enforceEx;
 	import std.file : readText;
-	import std.format : text;
+	import std.conv : text;
 
 	string[string] ret;
 	foreach (file; paths) {


### PR DESCRIPTION
Since leaking of Phobos import was fixed in 2.067 (by using more selective imports), this got caught.