### PR TITLE
Skip the backtick after `inlined code` so it doesn't remain in generated docs

### DIFF
--- a/src/ddoc/lexer.d
+++ b/src/ddoc/lexer.d
@@ -80,7 +80,7 @@ struct Lexer
 			{
 				current.text = text[offset .. inlineCode];
 				current.type = Type.inlined;
-				offset = inlineCode;
+				offset = inlineCode + 1;
 			}
 			return;
 		case ',':


### PR DESCRIPTION
Currently, 

```md
`inlined code`
```

generates something like:

```md
<pre style="display:inline;" class="d_inline_code">inline code</pre>`
```

That is, the trailing backtick is still in the output. This breaks `harbored-mod`, and probably `harbored` as well.

This pull request should fix this (but please check; I don't know if this change may cause other issue).