### PR TITLE
Fixed compilation with libdparse master

### DIFF
--- a/src/ddoc/highlight.d
+++ b/src/ddoc/highlight.d
@@ -166,7 +166,7 @@ unittest
 private:
 void highlightCode(O)(string code, ref O output)
 {
-	import std.d.lexer;
+	import dparse.lexer;
 	import std.string : representation;
 
 	enum fName = "<embedded-code-in-documentation>";


### PR DESCRIPTION
`libddoc` fails to build; seems to be out of sync with `libdparse` module name changes. This should fix it.