### PR TITLE
Call highlight before expanding macros in Params

### DIFF
--- a/src/ddoc/comments.d
+++ b/src/ddoc/comments.d
@@ -39,7 +39,7 @@ body
 		if (!doMapping(p[0]))
 			throw new DdocParseException("Unable to parse Key/Value pairs", p[0].content);
 		foreach (ref kv; p[0].mapping)
-			kv[1] = expand(Lexer(kv[1]), sMacros);
+			kv[1] = expand(Lexer(highlight(kv[1])), sMacros);
 	}
 
 	foreach (ref Section sec; sections)


### PR DESCRIPTION
`macros.expand` expects that input was parsed trough `highlight`
first.